### PR TITLE
fix: normalise ZoneGroup to array for single zone group setups

### DIFF
--- a/src/modules/common/sonosController.js
+++ b/src/modules/common/sonosController.js
@@ -100,7 +100,7 @@ export class SonosController {
     };
 
     // Search through all zone groups
-    const groups = jsonState?.ZoneGroups?.ZoneGroup || [];
+    const groups = [].concat(jsonState?.ZoneGroups?.ZoneGroup || []);
     for (const group of groups) {
       // Check main zone group member
       const member = group.ZoneGroupMember;
@@ -155,7 +155,7 @@ export class SonosController {
     };
 
     // Process all zone groups
-    const groups = jsonState?.ZoneGroups?.ZoneGroup || [];
+    const groups = [].concat(jsonState?.ZoneGroups?.ZoneGroup || []);
     for (const group of groups) {
       // Handle zone group members
       const members = group.ZoneGroupMember;


### PR DESCRIPTION
**Human writing:** Hi there.  Was working on a tweak to the plugin, and was getting an "Failed to get devices: groups is not iterable” error when trying to set Global Settings, so this is the fix Claude Code made to address that.  (I’ll open a separate PR for the feature work I did)


## Summary

- `convertXmlToJson` returns a plain object for single XML child elements, only promoting to an array when duplicate keys exist. When a Sonos network has only one zone group, `ZoneGroups.ZoneGroup` is an object rather than an array, causing `for...of` to throw "groups is not iterable".
- Wraps the result with `[].concat(...)` in both `getDeviceLocation` and `getDevices` so iteration always works regardless of the number of zone groups.

## Test plan

- [ ] Configure plugin with a Sonos setup that has a single zone group — saving global settings should succeed without "groups is not iterable" error
- [ ] Verify multi-zone setups continue to work normally

🤖 Generated with [Claude Code](https://claude.ai/claude-code)